### PR TITLE
Add placeholder implementations for NSProgress and NSURLSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 xcuserdata/
 *.xcworkspace/
 **/.gitignore
+.DS_Store

--- a/System/Foundation/Foundation.xcodeproj/project.pbxproj
+++ b/System/Foundation/Foundation.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 
 /* Begin PBXBuildFile section */
 		3F3EE9BD1A117EA000DEE62B /* _DebugUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F3EE9BB1A117EA000DEE62B /* _DebugUtils.m */; };
+		40BF65121A5E001E00CDF9AB /* NSURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = DE6F69C6188DBFE40053DD9B /* NSURLSession.m */; };
 		472583AE19074C0500BF7919 /* NSPredicateLexer.m in Sources */ = {isa = PBXBuildFile; fileRef = 472583AC19074C0500BF7919 /* NSPredicateLexer.m */; };
 		472583AF19074C0500BF7919 /* NSPredicateParser.tab.c in Sources */ = {isa = PBXBuildFile; fileRef = 472583AD19074C0500BF7919 /* NSPredicateParser.tab.c */; };
 		4787B2A019C11E9E00156B18 /* _NSFileIO.h in Headers */ = {isa = PBXBuildFile; fileRef = 4787B29E19C11E9E00156B18 /* _NSFileIO.h */; };
@@ -1280,6 +1281,7 @@
 				F82F8ED518983DB100AB6992 /* NSURLProtocol.m in Sources */,
 				F82F8ED618983DB100AB6992 /* NSURLRequest.m in Sources */,
 				F82F8ED718983DB100AB6992 /* NSURLResponse.m in Sources */,
+				40BF65121A5E001E00CDF9AB /* NSURLSession.m in Sources */,
 				F82F8ED818983DB100AB6992 /* NSUserDefaults.m in Sources */,
 				F82F8ED918983DB100AB6992 /* NSUUID.m in Sources */,
 				F82F8EDA18983DB100AB6992 /* NSValue.m in Sources */,

--- a/System/Foundation/include/Foundation/Foundation.h
+++ b/System/Foundation/include/Foundation/Foundation.h
@@ -47,6 +47,7 @@
 #import <Foundation/NSPointerFunctions.h>
 #import <Foundation/NSPort.h>
 #import <Foundation/NSProcessInfo.h>
+#import <Foundation/NSProgress.h>
 #import <Foundation/NSPropertyList.h>
 #import <Foundation/NSProxy.h>
 #import <Foundation/NSRange.h>

--- a/System/Foundation/include/Foundation/NSProgress.h
+++ b/System/Foundation/include/Foundation/NSProgress.h
@@ -1,11 +1,50 @@
 #import <Foundation/NSObject.h>
 
+@class NSDictionary;
+
 @interface NSProgress : NSObject
 
-+ (id)currentProgress;
-+ (id)progressWithTotalUnitCount:(int64_t)unitCount;
++ (NSProgress *)currentProgress;
++ (NSProgress *)progressWithTotalUnitCount:(int64_t)unitCount;
+- (instancetype)initWithParent:(NSProgress *)parentProgressOrNil userInfo:(NSDictionary *)userInfoOrNil NS_DESIGNATED_INITIALIZER;
+- (void)becomeCurrentWithPendingUnitCount:(int64_t)unitCount;
+- (void)resignCurrent;
 
-@property(readonly, getter=isCancelled) BOOL cancelled;
+@property int64_t totalUnitCount;
 @property int64_t completedUnitCount;
+@property (copy) NSString *localizedDescription;
+@property (copy) NSString *localizedAdditionalDescription;
+@property (getter=isCancellable) BOOL cancellable;
+@property (getter=isPausable) BOOL pausable;
+@property (readonly, getter=isCancelled) BOOL cancelled;
+@property (readonly, getter=isPaused) BOOL paused;
+
+#if NS_BLOCKS_AVAILABLE
+@property (copy) void (^cancellationHandler)(void);
+@property (copy) void (^pausingHandler)(void);
+#endif
+
+- (void)setUserInfoObject:(id)objectOrNil forKey:(NSString *)key;
+
+@property (readonly, getter=isIndeterminate) BOOL indeterminate;
+@property (readonly) double fractionCompleted;
+
+- (void)cancel;
+- (void)pause;
+
+@property (readonly, copy) NSDictionary *userInfo;
+@property (copy) NSString *kind;
 
 @end
+
+FOUNDATION_EXPORT NSString *const NSProgressEstimatedTimeRemainingKey NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressThroughputKey NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressKindFile NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileOperationKindKey NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileOperationKindDownloading NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileOperationKindDecompressingAfterDownloading NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileOperationKindReceiving NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileOperationKindCopying NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileURLKey NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileTotalCountKey NS_AVAILABLE(10_9, 7_0);
+FOUNDATION_EXPORT NSString *const NSProgressFileCompletedCountKey NS_AVAILABLE(10_9, 7_0);

--- a/System/Foundation/src/NSProgress.m
+++ b/System/Foundation/src/NSProgress.m
@@ -9,19 +9,36 @@
 
 @implementation NSProgress
 
-+ (id)currentProgress
++ (NSProgress *)currentProgress
 {
     return nil;
 }
 
-+ (id)progressWithTotalUnitCount:(int64_t)unitCount
++ (NSProgress *)progressWithTotalUnitCount:(int64_t)unitCount
 {
     return nil;
 }
 
-- (BOOL)isCancelled
+- (instancetype)initWithParent:(NSProgress *)parentProgressOrNil userInfo:(NSDictionary *)userInfoOrNil
 {
-    return NO;
+    return nil;
+}
+
+- (void)becomeCurrentWithPendingUnitCount:(int64_t)unitCount
+{
+}
+
+- (void)resignCurrent
+{
+}
+
+- (void)setTotalUnitCount:(int64_t)count
+{
+}
+
+- (int64_t)totalUnitCount
+{
+    return 0;
 }
 
 - (void)setCompletedUnitCount:(int64_t)count
@@ -31,6 +48,108 @@
 - (int64_t)completedUnitCount
 {
     return 0;
+}
+
+- (void)setLocalizedDescription:(NSString *)localizedDescription
+{
+}
+
+- (NSString *)localizedDescription
+{
+    return nil;
+}
+
+- (void)setLocalizedAdditionalDescription:(NSString *)localizedAdditionalDescription
+{
+}
+
+- (NSString *)localizedAdditionalDescription
+{
+    return nil;
+}
+
+- (void)setCancellable:(BOOL)cancellable
+{
+}
+
+- (BOOL)isCancellable
+{
+    return NO;
+}
+
+- (void)setPausable:(BOOL)pausable
+{
+}
+
+- (BOOL)isPausable
+{
+    return NO;
+}
+
+- (BOOL)isCancelled
+{
+    return NO;
+}
+
+- (BOOL)isPaused
+{
+    return NO;
+}
+
+#if NS_BLOCKS_AVAILABLE
+- (void)setCancellationHandler:(void (^)(void))cancellationHandler
+{
+}
+
+- (void (^)(void))cancellationHandler
+{
+    return nil;
+}
+
+- (void)setPausingHandler:(void (^)(void))pausingHandler
+{
+}
+
+- (void (^)(void))pausingHandler
+{
+    return nil;
+}
+#endif
+
+- (void)setUserInfoObject:(id)objectOrNil forKey:(NSString *)key
+{
+}
+
+- (BOOL)isIndeterminate
+{
+    return NO;
+}
+
+- (double)fractionCompleted
+{
+    return 0.0;
+}
+
+- (void)cancel
+{
+}
+
+- (void)pause
+{
+}
+
+- (NSDictionary *)userInfo
+{
+    return nil;
+}
+
+- (void)setKind:(NSString *)kind
+{
+}
+
+- (NSString *)kind
+{
+    return nil;
 }
 
 @end

--- a/System/Foundation/src/NSURLSession.m
+++ b/System/Foundation/src/NSURLSession.m
@@ -6,19 +6,25 @@
 //
 
 #import "NSURLSession.h"
-#import 
+
+#import <Foundation/NSException.h>
+
 const int64_t NSURLSessionTransferSizeUnknown = -1LL;
 
 @implementation NSURLSession
+@end
 
-+ (void)initialize
-{
-    static dispatch_once_t once = 0L;
-    dispatch_once(&once, ^{
-        Class cls = objc_lookupClass("__NSCFURLSession");
-        assert(cls != Nil);
-        class_setSuperclass(self, cls);
-    });
-}
+@implementation NSURLSessionConfiguration
+@end
 
+@implementation NSURLSessionTask
+@end
+
+@implementation NSURLSessionDataTask
+@end
+
+@implementation NSURLSessionUploadTask
+@end
+
+@implementation NSURLSessionDownloadTask
 @end


### PR DESCRIPTION
This was an attempt to get AFNetworking 2.x compiling with apportable. I was able to fill in the missing implementations in Foundation, but there was also a missing function declaration in Security.framework which is proprietary:

`AFSecurityPolicy.m:312: error: undefined reference to 'SecTrustSetPolicies'`

This change is released under the MIT license.
